### PR TITLE
Catch OverflowError in KeyCredential

### DIFF
--- a/dsinternals/common/data/hello/KeyCredential.py
+++ b/dsinternals/common/data/hello/KeyCredential.py
@@ -230,7 +230,10 @@ class KeyCredential(object):
                 _KeyApproximateLastLogonTimeStamp = ConvertFromBinaryTime(entry["data"], _KeySource, _Version)
 
             elif entry["entryType"] == KeyCredentialEntryType.KeyCreationTime.value:
-                _KeyCreationTime = ConvertFromBinaryTime(entry["data"], _KeySource, _Version)
+                try:
+                    _KeyCreationTime = ConvertFromBinaryTime(entry["data"], _KeySource, _Version)
+                except OverflowError:
+                    pass
 
             read_data = stream_data.read(3)
 


### PR DESCRIPTION
During a test I've used Pywhisker to list msKey credential attributes and this library threw an error on the KeyCreationTime. This pull requests catches this error for this specific key. And this solves the problem I had with Pywhisker.
