### PR TITLE
enable tox testing in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,42 @@
+[metadata]
+name = dsinternals
+version = 1.2.4
+description = Directory Services Internals Library
+url = http://github.com/p0dalirius/pydsinternals
+author = Podalirius
+author_email = podalirius@protonmail.com
+long_description = file:README.md
+long_description_content_type = text/markdown
+license = GPL2
+license_files = LICENSE
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.4',
+
+[options]
+python_requires = >=3.4
+install_requires = 
+    pyopenssl
+    pycryptodomex
+
+packages = find_namespace
+
+[options.packages.find]
+exclude =
+    tests
+
+[tox:tox]
+min_version = 1.4
+env_list =
+    py311
+    py310
+    py39
+    py36
+    type
+
+[testenv]
+deps = 
+commands = python3 -m unittest discover -v

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,15 +7,13 @@ author = Podalirius
 author_email = podalirius@protonmail.com
 long_description = file:README.md
 long_description_content_type = text/markdown
-license = GPL2
+license = GPLv2
 license_files = LICENSE
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-        "Operating System :: OS Independent",
-    ],
-    python_requires='>=3.4',
-
+classifiers =
+        Programming Language :: Python :: 3
+        License :: OSI Approved :: GNU General Public License v2 (GPLv2)
+        Operating System :: OS Independent
+    
 [options]
 python_requires = >=3.4
 install_requires = 


### PR DESCRIPTION
I have noticed that the empty setup.cfg disappeared from the tree since the last release.
Introducing this setup.cfg makes it possible to use tox for testing 
For example:
/usr/bin/python3 -m tox --current-env -q --recreate -e py311   

